### PR TITLE
feat : import support both app and VIA format

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import KeycodePicker from "@/components/KeycodePicker";
 import LayerSelector from "@/components/LayerSelector";
 import Toolbar from "@/components/Toolbar";
 import { parseViaDefinition } from "@/lib/parser";
-import { createDefaultKeymap, exportKeymap, importAnyKeymap, downloadJson } from "@/lib/keymap";
+import { createDefaultKeymap, exportKeymap, exportToVIA, importAnyKeymap, downloadJson } from "@/lib/keymap";
 import { ParsedLayout, Keymap, KeyboardDefinition } from "@/types/keyboard";
 
 import defaultKb from "../../keyboards/60-percent.json";
@@ -37,9 +37,24 @@ export default function Home() {
     [selectedKey, activeLayer]
   );
 
-  const handleExport = useCallback(() => {
-    const json = exportKeymap("My Keymap", kbName, keymap);
-    downloadJson(json, "keymap.json");
+  const handleExportVIA = useCallback(() => {
+    try {
+      const json = exportToVIA(keymap);
+      downloadJson(json, "via-keymap.json");
+    } catch (e) {
+      console.error(e);
+      alert("Failed to export VIA keymap")
+    }
+  }, [keymap]);
+
+  const handleExportKeylab = useCallback(() => {
+    try {
+      const json = exportKeymap("My Keymap", kbName, keymap);
+      downloadJson(json, "kyelab-keymap.json");
+    } catch (e) {
+      console.error(e);
+      alert("Failed to export keymap")
+    }
   }, [keymap, kbName]);
 
   const handleImport = useCallback(
@@ -94,7 +109,8 @@ export default function Home() {
           </p>
         </div>
         <Toolbar
-          onExport={handleExport}
+          onExportVIA={handleExportVIA}
+          onExportKeylab={handleExportKeylab}
           onImport={handleImport}
           onLoadKeyboard={handleLoadKeyboard}
         />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import KeycodePicker from "@/components/KeycodePicker";
 import LayerSelector from "@/components/LayerSelector";
 import Toolbar from "@/components/Toolbar";
 import { parseViaDefinition } from "@/lib/parser";
-import { createDefaultKeymap, exportKeymap, importKeymap, downloadJson } from "@/lib/keymap";
+import { createDefaultKeymap, exportKeymap, importAnyKeymap, downloadJson } from "@/lib/keymap";
 import { ParsedLayout, Keymap, KeyboardDefinition } from "@/types/keyboard";
 
 import defaultKb from "../../keyboards/60-percent.json";
@@ -45,22 +45,36 @@ export default function Home() {
   const handleImport = useCallback(
     (json: string) => {
       try {
-        const file = importKeymap(json);
+        const rawLayers = importAnyKeymap(json);
+        //Normalize layers length to match the current keyboard layout
+        const normalizedLayers = rawLayers.map((layer)=> {
+          const result =[...layer];
+          while(result.length < layout.keys.length){
+            result.push("KC_NO");
+          }
+
+          return result.slice(0,layout.keys.length);
+        })
+        
         // Pad layers to 4 if needed
-        while (file.layers.length < 4) {
-          file.layers.push(
+
+        while (normalizedLayers.length < 4) {
+          normalizedLayers.push(
             Array.from({ length: layout.keys.length }, () => "KC_NO")
           );
         }
-        setKeymap(file.layers);
+        setKeymap(normalizedLayers);
         setSelectedKey(null);
         setActiveLayer(0);
       } catch (e) {
+        console.error(e);
         alert("Invalid keymap file");
       }
     },
     [layout.keys.length]
   );
+
+  
 
   const handleLoadKeyboard = useCallback((json: string) => {
     try {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
   const handleExportKeylab = useCallback(() => {
     try {
       const json = exportKeymap("My Keymap", kbName, keymap);
-      downloadJson(json, "kyelab-keymap.json");
+      downloadJson(json, "zumap-keymap.json");
     } catch (e) {
       console.error(e);
       alert("Failed to export keymap")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,25 +45,9 @@ export default function Home() {
   const handleImport = useCallback(
     (json: string) => {
       try {
-        const rawLayers = importAnyKeymap(json);
-        //Normalize layers length to match the current keyboard layout
-        const normalizedLayers = rawLayers.map((layer)=> {
-          const result =[...layer];
-          while(result.length < layout.keys.length){
-            result.push("KC_NO");
-          }
-
-          return result.slice(0,layout.keys.length);
-        })
+        const layers = importAnyKeymap(json, layout.keys.length);
         
-        // Pad layers to 4 if needed
-
-        while (normalizedLayers.length < 4) {
-          normalizedLayers.push(
-            Array.from({ length: layout.keys.length }, () => "KC_NO")
-          );
-        }
-        setKeymap(normalizedLayers);
+        setKeymap(layers);
         setSelectedKey(null);
         setActiveLayer(0);
       } catch (e) {
@@ -73,8 +57,6 @@ export default function Home() {
     },
     [layout.keys.length]
   );
-
-  
 
   const handleLoadKeyboard = useCallback((json: string) => {
     try {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -3,12 +3,13 @@
 import { useRef } from "react";
 
 interface Props {
-  onExport: () => void;
+  onExportVIA: () => void;
+  onExportKeylab: () => void;
   onImport: (json: string) => void;
   onLoadKeyboard: (json: string) => void;
 }
 
-export default function Toolbar({ onExport, onImport, onLoadKeyboard }: Props) {
+export default function Toolbar({ onExportVIA, onExportKeylab, onImport, onLoadKeyboard }: Props) {
   const keymapInputRef = useRef<HTMLInputElement>(null);
   const kbInputRef = useRef<HTMLInputElement>(null);
 
@@ -27,11 +28,19 @@ export default function Toolbar({ onExport, onImport, onLoadKeyboard }: Props) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <button
-        onClick={onExport}
+        onClick={onExportVIA}
         className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 transition-colors"
       >
-        Export Keymap
+        Export VIA
       </button>
+
+      <button
+        onClick={onExportKeylab}
+        className="rounded bg-zinc-700 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 transition-colors"
+      >
+        Export Keylab
+      </button>
+
       <button
         onClick={() => keymapInputRef.current?.click()}
         className="rounded bg-zinc-700 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-600 transition-colors"

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -25,50 +25,62 @@ export function exportKeymap(
 
 /** Detect what type of JSON is being imported and then update */
 
-export function importAnyKeymap(json : string): Keymap {
-  const parsed = JSON.parse(json);
-  if(typeof parsed.version === "number" && Array.isArray(parsed.layers)){
-    validateLayers(parsed.layers);
-    return parsed.layers;
+export function importAnyKeymap(
+  json: string,
+  keyCount: number
+): Keymap {
+  let parsed;
+
+  try { 
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Invalid JSON.");
   }
 
-  if(parsed.layers && Array.isArray(parsed.layers)){
+  if (Array.isArray(parsed.layers)) {
     validateLayers(parsed.layers);
-    return parsed.layers;
+    
+    // Normalization logic
+    const normalizedLayers: Keymap = parsed.layers.map((layer: string[]) => {
+      const result = [...layer];
+      while (result.length < keyCount) {
+       result.push("KC_NO");
+      }
+
+      return result.slice(0, keyCount);
+    })
+
+    // Ensure minimum layers
+    while (normalizedLayers.length < NUM_LAYERS) {
+      normalizedLayers.push(
+        Array.from({ length: keyCount }, () => "KC_NO")
+      );
+    }
+
+    return normalizedLayers;
   }
 
-  throw new Error("Invalid keymap format")
+  throw new Error("Invalid keymap format");
 }
 
 /** Function to validate the layers of the JSON file */
 
-function validateLayers(layers : any){
-  if(!Array.isArray(layers)){
+function validateLayers(layers: unknown): asserts layers is Keymap {
+  if (!Array.isArray(layers)) {
     throw new Error("Layers must be an array");
   }
 
-  for(const layer of layers){
-    if(!Array.isArray(layer)){
+  for (const layer of layers) {
+    if (!Array.isArray(layer)) {
       throw new Error("Each layer must be an array");
     }
 
-    for(const key of layer){
-      if(typeof key!== "string"){
+    for (const key of layer) {
+      if (typeof key !== "string") {
         throw new Error("Keycodes must be strings");
       }
     }
-
   }
-  
-}
-
-/** Parse an imported keymap JSON string */
-export function importKeymap(json: string): KeymapFile {
-  const parsed = JSON.parse(json);
-  if (!parsed.layers || !Array.isArray(parsed.layers)) {
-    throw new Error("Invalid keymap file: missing layers array");
-  }
-  return parsed as KeymapFile;
 }
 
 /** Download a string as a file */

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -23,6 +23,45 @@ export function exportKeymap(
   return JSON.stringify(file, null, 2);
 }
 
+/** Detect what type of JSON is being imported and then update */
+
+export function importAnyKeymap(json : string): Keymap {
+  const parsed = JSON.parse(json);
+  if(typeof parsed.version === "number" && Array.isArray(parsed.layers)){
+    validateLayers(parsed.layers);
+    return parsed.layers;
+  }
+
+  if(parsed.layers && Array.isArray(parsed.layers)){
+    validateLayers(parsed.layers);
+    return parsed.layers;
+  }
+
+  throw new Error("Invalid keymap format")
+}
+
+/** Function to validate the layers of the JSON file */
+
+function validateLayers(layers : any){
+  if(!Array.isArray(layers)){
+    throw new Error("Layers must be an array");
+  }
+
+  for(const layer of layers){
+    if(!Array.isArray(layer)){
+      throw new Error("Each layer must be an array");
+    }
+
+    for(const key of layer){
+      if(typeof key!== "string"){
+        throw new Error("Keycodes must be strings");
+      }
+    }
+
+  }
+  
+}
+
 /** Parse an imported keymap JSON string */
 export function importKeymap(json: string): KeymapFile {
   const parsed = JSON.parse(json);

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -13,6 +13,31 @@ export function createDefaultKeymap(layout: ParsedLayout): Keymap {
   );
 }
 
+function trimEmptyLayers(layers: Keymap): Keymap {
+  const trimmed = layers.filter(layer =>
+    layer.some(key => key !== "KC_NO")
+  );
+
+  return trimmed.length > 0 ? trimmed : layers.slice(0,1);
+}
+
+/** Export to VIA format */
+export function exportToVIA(layers: Keymap): string {
+  if (!Array.isArray(layers)) {
+    throw new Error("Invalid keymap format")
+  }
+
+  //validating again
+  validateLayers(layers)
+
+  const viaFormat = {
+    version: 1,
+    layers: trimEmptyLayers(layers),
+  }
+
+  return JSON.stringify(viaFormat, null, 2);
+}
+
 /** Export keymap as a downloadable JSON file */
 export function exportKeymap(
   name: string,


### PR DESCRIPTION
## Overview

Adds full support for importing and exporting VIA-compatible keymap JSON files.

This enables interoperability with the VIA ecosystem while preserving compatibility with KeyLab’s internal keymap format.

---

## Problem

Previously, the application only supported its internal keymap format:

```json
{ "name": "...", "keyboard": "...", "layers": [...] }
```

This made it incompatible with VIA keymaps, which use:

```json
{ "version": 1, "layers": [...] }
```

## Solution

### Import
* Added importAnyKeymap to support both:
    * VIA format: `{ version, layers }`
    * KeyLab format: `{ name, keyboard, layers }`
* Centralized import logic in keymap.ts:
    * JSON parsing
    * Structure validation (validateLayers)
    * Layer normalization
* Implemented normalization:
    * Pads layers with "KC_NO" if too short
    * Trims layers if too long
    * Ensures a minimum number of layers
* Simplified handleImport in page.tsx to only handle state updates

### Export

* Added exportToVIA for VIA-compatible export:

```json
{ "version": 1, "layers": [...] }
```

* Retained exportKeymap for internal KeyLab format:

```json
{ "name": "...", "keyboard": "...", "layers": [...] }
```
* Ensures exported keymaps reflect normalized internal state

## UI Changes
* Updated toolbar to include two export options:
    * Export VIA (primary)
    * Export KeyLab (secondary)
* Added separate handlers:
    * handleExportVIA
    * handleExportKeyLab
* Kept UI simple and consistent with existing design

## Behavior
### Import
* Accepts:
    * VIA format: { version, layers }
    * KeyLab format: { name, keyboard, layers }
* Validates structure and keycodes
* Automatically normalizes:
    * Layer length to match keyboard layout
    * Ensures minimum number of layers
### Export
* VIA export produces standard VIA-compatible JSON
* KeyLab export preserves metadata for re-import

## Design Notes
* Import logic is fully self-contained in keymap.ts
* UI layer is simplified and only manages state
* No breaking changes to existing functionality
* Code formatting and style aligned with project conventions

Related to issue #4

### Updates
- Moved normalization logic from `page.tsx` to `keymap.ts`
- Simplified `importAnyKeymap`
- Removed old `importKeymap`
- Addressed initial review feedback
- Ensured consistent formatting across the codebase

Adding images for reference

on importing 

data = {
  "version": 1,
  "layers": [
    [
      "KC_Q","KC_W","KC_E","KC_R","KC_T",
      "KC_Y","KC_U","KC_I","KC_O","KC_P",
      "KC_A","KC_S","KC_D","KC_F","KC_G"
    ]
  ]
}

we get 

<img width="1840" height="895" alt="image" src="https://github.com/user-attachments/assets/abe88729-c41e-469a-badd-a657f0612b9c" />

Final UI

<img width="1840" height="895" alt="image" src="https://github.com/user-attachments/assets/4cec36b3-de86-4fd1-88b8-9ca38e17b04a" />

Export VIA - highlighted 




