### PR TITLE
docs: improve developer setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,28 @@ Thanks for your interest in contributing! Here's how to get started.
 
 ## Development Setup
 
+### Prerequisites
+
+- Node.js 20 or newer
+- npm 10 or newer
+- Git
+
 ```bash
-git clone https://github.com/zumap/zumap.git
-cd zumap
+git clone https://github.com/Keylab-dev/keylab.git
+cd keylab
 npm install
 npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to test changes locally.
+
+### Validation
+
+Run these before submitting a pull request:
+
+```bash
+npm run lint
+npm run build
 ```
 
 ## Ways to Contribute
@@ -37,8 +54,8 @@ Check the roadmap in README.md. Open an issue to discuss before starting large c
 1. Fork and create a feature branch
 2. Make your changes
 3. Test locally with `npm run dev`
-4. Run `npm run build` to check for errors
-5. Submit a PR with a clear description
+4. Run `npm run lint` and `npm run build`
+5. Submit a PR with a clear description, screenshots for UI changes, and any manual test notes
 
 ## Keyboard Definition Guidelines
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,36 @@ An open-source, VIA-compatible keyboard configurator for the web. Load any keybo
 
 ## Getting Started
 
+### Prerequisites
+
+- Node.js 20 or newer
+- npm 10 or newer
+- Git
+
 ```bash
-git clone https://github.com/zumap/zumap.git
-cd zumap
+git clone https://github.com/Keylab-dev/keylab.git
+cd keylab
 npm install
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
+
+### Development Commands
+
+```bash
+npm run dev      # Start the local Next.js development server
+npm run lint     # Run ESLint
+npm run build    # Create a production build
+npm run start    # Serve the production build after npm run build
+```
+
+Before opening a pull request, run:
+
+```bash
+npm run lint
+npm run build
+```
 
 ## Project Structure
 
@@ -43,6 +65,12 @@ src/
     parser.ts    → VIA JSON → renderable layout parser
   types/         → TypeScript type definitions
 ```
+
+### Architecture Overview
+
+Zumap is a client-side Next.js app. The UI lives in `src/components/`, route-level pages live in `src/app/`, and the
+keyboard/keymap logic lives in `src/lib/`. VIA keyboard definition files are loaded from `keyboards/`, while reusable
+keymap presets live in `keymaps/`.
 
 ## Adding a Keyboard
 


### PR DESCRIPTION
Fixes #16.

This makes the developer setup path more complete and easier to verify for new contributors.

Changes:
- Correct the clone URL and local directory name to match this repository.
- Add Node/npm/Git prerequisites.
- Document the local development, lint, build, and production-start commands.
- Add a short architecture overview for the Next.js app structure.
- Expand the pull-request checklist in `CONTRIBUTING.md` to include lint/build validation and manual test notes.

Validation:
- `npm install` completed.
- `npm run build` passed.
- Direct content check confirmed the updated setup commands and architecture overview.
- `git diff --check`

Note: `npm run lint` was attempted and failed on existing source issues unrelated to this docs change:
- `src/types/keyboard.ts`: `@typescript-eslint/no-explicit-any`
- unused variable warnings in `src/app/page.tsx` and `src/components/KeycodePicker.tsx`
